### PR TITLE
Iot services client implementations

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -1,0 +1,29 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+export default {
+  get: jest.fn(() => {
+    Promise.resolve({ data: {} });
+  }),
+  post: jest.fn(() => {
+    Promise.resolve({ data: {} });
+  }),
+};

--- a/__tests__/encoder-client.spec.js
+++ b/__tests__/encoder-client.spec.js
@@ -1,0 +1,136 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+import mockAxios from 'axios';
+import EncoderClient from '../src/api/encoder-client';
+import EncoderError from '../src/api/errors/encoder-error';
+
+describe('Encoder client', () => {
+  afterEach(() => {
+    mockAxios.post.mockClear();
+  });
+
+  const encoder = new EncoderClient('https://encoder.test');
+
+  const streamConfiguration = {
+    device_token: 'abc123',
+    community_id: 'a8463397-2411-4f4a-8294-eef41dc41a5e',
+    recipient_public_key: 'f99538cf2b2d5472c0da9316b1b51b55',
+    location: {
+      longitude: 2.512,
+      latitude: 54.125,
+    },
+    exposure: 'INDOOR',
+    operations: [],
+  };
+
+  const stream = {
+    stream_uid: 'd5eae59b-050f-4f64-bf8c-4c9b7e39ff9a',
+    token: 'isM4wxuUH3JDrUOg7WvDBdHx4mQiMyW4A3h0Amfzg2I=',
+  };
+
+  test('should set full url when constructed', () => {
+    expect(encoder.url).toEqual('https://encoder.test/twirp/decode.iot.encoder.Encoder');
+  });
+
+  test('should use default base url if none supplied', () => {
+    const defaultEncoder = new EncoderClient();
+    expect(defaultEncoder.url).toEqual('https://encoder.decodeproject.eu/twirp/decode.iot.encoder.Encoder');
+  });
+
+  test('should create stream', async () => {
+    // define our mocked response
+    mockAxios.post.mockImplementationOnce(() => Promise.resolve({
+      data: stream,
+    }));
+
+
+    const response = await encoder.createStream(streamConfiguration);
+    expect(response).toEqual(stream);
+
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      'https://encoder.test/twirp/decode.iot.encoder.Encoder/CreateStream',
+      streamConfiguration,
+      {
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+    expect(mockAxios.post).toHaveBeenCalledTimes(1);
+  });
+
+  test('should throw an error on failure', async () => {
+    mockAxios.post.mockRejectedValueOnce({
+      response: {
+        data: {
+          msg: 'An error occurred',
+          meta: {
+            twirp_invalid_route: 'POST /foo',
+          },
+        },
+      },
+    });
+
+    try {
+      await encoder.createStream(streamConfiguration);
+    } catch (e) {
+      expect(e).toBeInstanceOf(EncoderError);
+      expect(e.message).toBe('Error creating stream: An error occurred');
+    }
+  });
+
+  test('should delete stream', async () => {
+    // define our mocked response
+    mockAxios.post.mockImplementationOnce(() => Promise.resolve({
+      data: {},
+    }));
+
+    await encoder.deleteStream(stream);
+
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      'https://encoder.test/twirp/decode.iot.encoder.Encoder/DeleteStream',
+      stream,
+      {
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+    expect(mockAxios.post).toHaveBeenCalledTimes(1);
+  });
+
+  test('should throw an error on failure', async () => {
+    mockAxios.post.mockRejectedValueOnce({
+      response: {
+        data: {
+          msg: 'An error occurred',
+          meta: {
+            twirp_invalid_route: 'POST /foo',
+          },
+        },
+      },
+    });
+
+    try {
+      await encoder.deleteStream(stream);
+    } catch (e) {
+      expect(e).toBeInstanceOf(EncoderError);
+      expect(e.message).toBe('Error deleting stream: An error occurred');
+    }
+  });
+});

--- a/__tests__/policystore-client.spec.js
+++ b/__tests__/policystore-client.spec.js
@@ -34,6 +34,11 @@ describe('Policystore client', () => {
     expect(policystore.url).toEqual('https://policystore.test/twirp/decode.iot.policystore.PolicyStore');
   });
 
+  test('should use default policystore url if none supplied', () => {
+    const defaultPolicystore = new PolicystoreClient();
+    expect(defaultPolicystore.url).toEqual('https://policystore.decodeproject.eu/twirp/decode.iot.policystore.PolicyStore');
+  });
+
   test('should return policies', async () => {
     mockAxios.post.mockImplementationOnce(() => Promise.resolve({
       data: {

--- a/__tests__/policystore-client.spec.js
+++ b/__tests__/policystore-client.spec.js
@@ -1,0 +1,103 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+import mockAxios from 'axios';
+import PolicystoreClient from 'api/policystore-client';
+import PolicystoreError from '../src/api/errors/policystore-error';
+
+describe('Policystore client', () => {
+  afterEach(() => {
+    mockAxios.post.mockClear();
+  });
+
+  const policystore = new PolicystoreClient('https://policystore.test');
+
+  test('should set url prefix when constructed', () => {
+    expect(policystore.url).toEqual('https://policystore.test/twirp/decode.iot.policystore.PolicyStore');
+  });
+
+  test('should return policies', async () => {
+    mockAxios.post.mockImplementationOnce(() => Promise.resolve({
+      data: {
+        policies: [
+          {
+            community_id: 'community-id',
+            label: 'All Public',
+            operations: [],
+            public_key: 'public-key',
+            authorizable_attribute_id: 'authorizable-attribute-id',
+            credential_issuer_endpoint_url: 'https://credentials.decodeproject.eu',
+            descriptions: {
+              ca: 'Una comunitat que comparteix totes les dades.',
+              en: 'A community that shares all data.',
+              es: 'Una comunidad que comparte todos los datos.',
+            },
+          },
+        ],
+      },
+    }));
+
+    const response = await policystore.listPolicies();
+    expect(response).toEqual([
+      {
+        community_id: 'community-id',
+        label: 'All Public',
+        operations: [],
+        public_key: 'public-key',
+        authorizable_attribute_id: 'authorizable-attribute-id',
+        credential_issuer_endpoint_url: 'https://credentials.decodeproject.eu',
+        descriptions: {
+          ca: 'Una comunitat que comparteix totes les dades.',
+          en: 'A community that shares all data.',
+          es: 'Una comunidad que comparte todos los datos.',
+        },
+      },
+    ]);
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      'https://policystore.test/twirp/decode.iot.policystore.PolicyStore/ListEntitlementPolicies',
+      {},
+      {
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+    expect(mockAxios.post).toHaveBeenCalledTimes(1);
+  });
+
+  test('should throw an error on failure', async () => {
+    mockAxios.post.mockRejectedValueOnce({
+      response: {
+        data: {
+          msg: 'An error occurred',
+          meta: {
+            twirp_invalid_route: 'POST /foo',
+          },
+        },
+      },
+    });
+
+    try {
+      await policystore.listPolicies();
+    } catch (e) {
+      expect(e).toBeInstanceOf(PolicystoreError);
+      expect(e.message).toBe('Error listing policies: An error occurred');
+    }
+  });
+});

--- a/src/api/encoder-client.js
+++ b/src/api/encoder-client.js
@@ -1,0 +1,82 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+import axios from 'axios';
+import { debugLog } from 'lib/utils';
+import EncoderError from './errors/encoder-error';
+
+const prefix = '/twirp/decode.iot.encoder.Encoder';
+
+/**
+ * Client for the IoT Stream Encoder. Exposes methods for creating or deleting
+ * encrypted streams on the stream encoder service.
+ */
+class EncoderClient {
+  constructor(url = 'https://encoder.decodeproject.eu') {
+    this.url = `${url}${prefix}`;
+  }
+
+  /**
+   * Create an encoded stream for a device which will start that device
+   * collecting data for the chosen community.
+   *
+   * @param {StreamConfiguration} streamConfiguration - Configuration of the
+   *     new encrypted stream to create
+   * @return {Stream}
+   */
+  async createStream(streamConfiguration) {
+    try {
+      const url = `${this.url}/CreateStream`;
+      debugLog('Going to call: ', url);
+
+      const { data: stream } = await axios.post(url, streamConfiguration, { headers: { 'Content-Type': 'application/json' } });
+      debugLog('Response: ', stream);
+      return stream;
+    } catch (err) {
+      debugLog('Error: ', err);
+      const { response: { data: { msg, meta } } } = err;
+      debugLog('Error details: ', JSON.stringify(meta));
+      throw new EncoderError(`Error creating stream: ${msg}`);
+    }
+  }
+
+  /**
+   * Delete an encoded stream, so stopping any new data being encrypted and
+   * stored for that device configuration.
+   *
+   * @param {Stream} stream - The stream to delete
+   */
+  async deleteStream(stream) {
+    try {
+      const url = `${this.url}/DeleteStream`;
+      debugLog('Going to call: ', url);
+
+      await axios.post(url, stream, { headers: { 'Content-Type': 'application/json' } });
+    } catch (err) {
+      debugLog('Error: ', err);
+      const { response: { data: { msg, meta } } } = err;
+      debugLog('Error details: ', JSON.stringify(meta));
+      throw new EncoderError(`Error deleting stream: ${msg}`);
+    }
+  }
+}
+
+export default EncoderClient;

--- a/src/api/errors/encoder-error.js
+++ b/src/api/errors/encoder-error.js
@@ -1,0 +1,28 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+class EncoderError {
+  constructor(message) {
+    this.message = message || 'There was an error calling the IoT encoder service';
+  }
+}
+
+export default EncoderError;

--- a/src/api/errors/policystore-error.js
+++ b/src/api/errors/policystore-error.js
@@ -1,0 +1,28 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+class PolicystoreError {
+  constructor(message) {
+    this.message = message || 'There was an error calling the IoT policystore service';
+  }
+}
+
+export default PolicystoreError;

--- a/src/api/policystore-client.js
+++ b/src/api/policystore-client.js
@@ -1,0 +1,94 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+import axios from 'axios';
+import { debugLog } from 'lib/utils';
+import PolicystoreError from './errors/policystore-error';
+
+const prefix = '/twirp/decode.iot.policystore.PolicyStore';
+
+/**
+ * @typedef {Object} Policy - Object containing the definition of a community
+ *     policy
+ * @property {string} community_id - Identifier of the community
+ * @property {string} label - The title of the community
+ * @property {Object} descriptions - Object containing translated descriptions
+ *     of the community
+ * @property {string} descriptions.ca - Català language description of the
+ *     community
+ * @property {string} descriptions.en - English language description of the
+ *     community
+ * @property {string} descriptions.es - Castellano language description of the
+ *     community
+ * @property {Object[]} operations - List of operations to apply to the device
+ * @property {number} operations[].sensor_id - Numeric identifier of a sensor
+ * @property {string} operations[].action - Action to apply to the sensor (one
+ *     of SHARE, BIN, MOVING_AVG)
+ * @property {number[]} operations[].bins - Array of numbers defining a set of
+ *     bins into which values should be classified. Required for BIN, an error if
+ *     present for other actions
+ * @property {number} operations[].interval - Interval in seconds over which
+ *     moving average should be calculated. Required for MOVING_AVG, an error if
+ *     present for other actions
+ * @property {string} public_key - Public key part of the communities'
+ *     encryption keypair
+ * @property {string} authorizable_attribute_id - Identifier of the authorizable
+ *     attribute id used for the Coconut flow
+ * @property {string} credential_issuer_endpoint_url - URL to which Coconut auth
+ *     requests should be sent
+ */
+
+/**
+ * Client for the IoT Policystore. The Policystore maintains a list of
+ * available communities which users may choose to add their device to. Joining
+ * a community means creating an encrypted stream which processes and
+ * transforms the data using the operations defined in the communities policy
+ * and encrypting the data with the credentials belonging to the community.
+ */
+class PolicystoreClient {
+  constructor(url = 'https://policystore.decodeproject.eu') {
+    this.url = `${url}${prefix}`;
+  }
+
+  /**
+   * Returns a list of available community policies that a user may choose to
+   * add their device to.
+   *
+   * @return {Policy[]} - the list of policies
+   */
+  async listPolicies() {
+    try {
+      const url = `${this.url}/ListEntitlementPolicies`;
+      debugLog('Going to call: ', url);
+
+      const { data: { policies } } = await axios.post(url, {}, { headers: { 'Content-Type': 'application/json' } });
+      debugLog('Response: ', policies);
+      return policies;
+    } catch (error) {
+      debugLog('Error: ', error);
+      const { response: { data: { msg, meta } } } = error;
+      debugLog('Error data: ', JSON.stringify(meta));
+      throw new PolicystoreError(`Error listing policies: ${msg}`);
+    }
+  }
+}
+
+export default PolicystoreClient;

--- a/src/api/policystore-client.js
+++ b/src/api/policystore-client.js
@@ -26,37 +26,6 @@ import PolicystoreError from './errors/policystore-error';
 const prefix = '/twirp/decode.iot.policystore.PolicyStore';
 
 /**
- * @typedef {Object} Policy - Object containing the definition of a community
- *     policy
- * @property {string} community_id - Identifier of the community
- * @property {string} label - The title of the community
- * @property {Object} descriptions - Object containing translated descriptions
- *     of the community
- * @property {string} descriptions.ca - Català language description of the
- *     community
- * @property {string} descriptions.en - English language description of the
- *     community
- * @property {string} descriptions.es - Castellano language description of the
- *     community
- * @property {Object[]} operations - List of operations to apply to the device
- * @property {number} operations[].sensor_id - Numeric identifier of a sensor
- * @property {string} operations[].action - Action to apply to the sensor (one
- *     of SHARE, BIN, MOVING_AVG)
- * @property {number[]} operations[].bins - Array of numbers defining a set of
- *     bins into which values should be classified. Required for BIN, an error if
- *     present for other actions
- * @property {number} operations[].interval - Interval in seconds over which
- *     moving average should be calculated. Required for MOVING_AVG, an error if
- *     present for other actions
- * @property {string} public_key - Public key part of the communities'
- *     encryption keypair
- * @property {string} authorizable_attribute_id - Identifier of the authorizable
- *     attribute id used for the Coconut flow
- * @property {string} credential_issuer_endpoint_url - URL to which Coconut auth
- *     requests should be sent
- */
-
-/**
  * Client for the IoT Policystore. The Policystore maintains a list of
  * available communities which users may choose to add their device to. Joining
  * a community means creating an encrypted stream which processes and


### PR DESCRIPTION
This PR contains an implementation of the client for the IoT policystore along with some simple test cases. The test cases are perhaps overkill but I wanted to include them because I'm not running the full app and the test cases provide me with some reassurance that I'm not pushing completely broken code.

Following this PR will be a second one containing the stream encoder client, separated for clarity.

I know @jordibuj you are primarily concerned with test coverage for the "business logic" in the redux core, so I'm hoping this implementation is straightforward for you to integrate (as redux makes my head hurt). Any questions obviously please let me know